### PR TITLE
Fix Open Graph fallback

### DIFF
--- a/src/_data.json
+++ b/src/_data.json
@@ -1,0 +1,8 @@
+{
+  "openGraph": {
+    "title": "Featurist - Full stack, feature driven development teams",
+    "description":
+      "We build mobile and web apps for startups through to large enterprises, work with established companies to transform legacy systems and make open source tools to aid our work and contribute to the community.",
+    "image": "https://www.featurist.co.uk/images/tile.png"
+  }
+}

--- a/src/_partials/metadata.ejs
+++ b/src/_partials/metadata.ejs
@@ -1,9 +1,9 @@
 <meta name="description" content="<%= description %>">
 
 <meta property="og:site_name" content="Featurist">
-<meta property="og:title" content="<%= openGraph.title %>">
-<meta property="og:description" content="<%= openGraph.description %>">
-<meta property="og:image" content="<%= openGraph.image %>">
+<meta property="og:title" content="<%= openGraph.title || public._data.openGraph.title %>">
+<meta property="og:description" content="<%= openGraph.description || public._data.openGraph.description %>">
+<meta property="og:image" content="<%= openGraph.image || public._data.openGraph.image %>">
 <meta property="og:url" content="">
 <meta property="og:locale" content="en_GB">
 <meta property="og:type" content="website">

--- a/src/about/_data.json
+++ b/src/about/_data.json
@@ -5,8 +5,7 @@
     "description": "Learn about our development process and beliefs.",
     "openGraph": {
       "title": "About Featurist",
-      "description": "Learn about our development process and beliefs.",
-      "image": "https://www.featurist.co.uk/images/tile.png"
+      "description": "Learn about our development process and beliefs."
     }
   }
 }

--- a/src/careers/_data.json
+++ b/src/careers/_data.json
@@ -7,8 +7,7 @@
     "openGraph": {
       "title": "Careers at Featurist",
       "description":
-        "Featurist is a welcoming and flexible team of remote software professionals.",
-      "image": "https://www.featurist.co.uk/images/tile.png"
+        "Featurist is a welcoming and flexible team of remote software professionals."
     }
   }
 }

--- a/src/contact/_data.json
+++ b/src/contact/_data.json
@@ -5,8 +5,7 @@
     "description": "Get in touch to discuss your project.",
     "openGraph": {
       "title": "Contact Featurist Today",
-      "description": "Get in touch to discuss how we can help your company.",
-      "image": "https://www.featurist.co.uk/images/tile.png"
+      "description": "Get in touch to discuss how we can help your company."
     }
   }
 }

--- a/src/learn/_data.json
+++ b/src/learn/_data.json
@@ -7,8 +7,7 @@
     "openGraph": {
       "title": "Learn",
       "description":
-        "At Featurist we love to spread knowledge. You can regularly find us attending meetups and speaking at conferences or running courses. Here are some of our previous events.",
-      "image": "https://www.featurist.co.uk/images/tile.png"
+        "At Featurist we love to spread knowledge. You can regularly find us attending meetups and speaking at conferences or running courses. Here are some of our previous events."
     }
   },
   "events": {

--- a/src/projects/_data.json
+++ b/src/projects/_data.json
@@ -7,8 +7,7 @@
     "openGraph": {
       "title": "Our Open-source Projects",
       "description":
-        "We are passionate about contributing to the open-source community. Check out some of our projects.",
-      "image": "https://www.featurist.co.uk/images/tile.png"
+        "We are passionate about contributing to the open-source community. Check out some of our projects."
     }
   },
   "projects": {

--- a/src/work/_data.json
+++ b/src/work/_data.json
@@ -7,8 +7,7 @@
     "openGraph": {
       "title": "Our Work",
       "description":
-        "We've built mobile and web apps for startups through to large enterprises, and worked with established companies to transform legacy systems. Read about our past clients to get a better idea of how we work.",
-      "image": "https://www.featurist.co.uk/images/tile.png"
+        "We've built mobile and web apps for startups through to large enterprises, and worked with established companies to transform legacy systems. Read about our past clients to get a better idea of how we work."
     }
   },
   "clients": {


### PR DESCRIPTION
### Current Problem

Tweets [like this](https://twitter.com/featurists/status/1092797079305547777) linking to pages [like this](https://www.featurist.co.uk/learn/test-commit-revert/) aren't showing our logo in the image slot in the Tweet. The Open Graph fallback is broken, or maybe never worked.

### Solution

Fix that. Individual pages can still set their open Open Graph data including image, but now the fallback to the default values should work correctly.